### PR TITLE
Add command 'make' for installing local modules

### DIFF
--- a/luadist.lua
+++ b/luadist.lua
@@ -25,6 +25,7 @@ Usage: luadist [DEPLOYMENT_DIRECTORY] <COMMAND> [ARGUMENTS...] [-VARIABLES...]
 
         help      - print this help
         install   - install modules
+        make      - make local modules
         remove    - remove modules
         list      - list installed modules
         info      - show information about modules
@@ -84,6 +85,50 @@ Usage: luadist [DEPLOYMENT_DIRECTORY] install MODULES... [-VARIABLES...]
             end
 
             local ok, err, status = dist.install(modules, deploy_dir, cmake_variables)
+            if not ok then
+                print(err)
+                os.exit(status)
+            else
+                print("Installation successful.")
+                return 0
+            end
+        end
+    },
+
+    -- Make modules.
+    ["make"] = {
+        help = [[
+Usage: luadist [DEPLOYMENT_DIRECTORY] make MODULES... [-VARIABLES...]
+
+    The 'make' command will install specified MODULES to
+    DEPLOYMENT_DIRECTORY.
+    MODULES with all dependencies that are not installed have to be present in the DEPLOYMENT_DIRECTORY saved in
+    subdirectories named 'module version'.
+    LuaDist will also automatically resolve and install all dependencies, if they are available. 
+
+    If DEPLOYMENT_DIRECTORY is not specified, the deployment directory
+    of LuaDist is used.
+
+    Optional CMake VARIABLES in -D format (e.g. -Dvariable=value) or LuaDist
+    configuration VARIABLES (e.g. -variable=value) can be specified.
+        ]],
+
+        run = function (deploy_dir, modules, cmake_variables)
+            deploy_dir = deploy_dir or cfg.root_dir
+            if type(modules) == "string" then modules = {modules} end
+            cmake_variables = cmake_variables or {}
+
+            assert(type(deploy_dir) == "string", "luadist.make: Argument 'deploy_dir' is not a string.")
+            assert(type(modules) == "table", "luadist.make: Argument 'modules' is not a string or table.")
+            assert(type(cmake_variables) == "table", "luadist.make: Argument 'cmake_variables' is not a table.")
+            deploy_dir = pl.path.abspath(deploy_dir)
+
+            if #modules == 0 then
+                print("No modules to make specified.")
+                return 0
+            end
+
+            local ok, err, status = dist.make(modules, deploy_dir, cmake_variables)
             if not ok then
                 print(err)
                 os.exit(status)

--- a/luadist2-0.6-4.rockspec
+++ b/luadist2-0.6-4.rockspec
@@ -1,7 +1,7 @@
 package = "luadist2"
-version = "0.6-4"
+version = "0.7"
 source = {
-    tag = "0.6-4",
+    tag = "0.7",
     url = "git://github.com/LuaDist-core/luadist2.git"
 }
 description = {


### PR DESCRIPTION
The current version of LuaDist does not support installation of
local modules. Every module has to be downloaded from remote repo.
To edit the dependencies of module the manifest in remote repo
has to be modified also.

Module including all its missing (not installed) dependencies has to
be present in the 'deploy_dir' in subdirectory named 'module version', e.g.
'yaml 1.1.2-1'. Local manifest with all modules in the 'deploy_dir' is created.

The make command will provide option to install modules saved
in the local file system without necessity of downloading them from
remote repo. Developing and testing of modules will become easier and
more straightforward.