### PR TITLE
 Fix command 'make' , add local repos support, edit version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 project(luadist2 C CXX)
-set(luadist2_VERSION 0.5-1)
+set(luadist2_VERSION 0.7)
 
 set(ENV{LUA_DIR} ${CMAKE_INSTALL_PREFIX})
 find_package(Lua REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 project(luadist2 C CXX)
-set(luadist2_VERSION 0.7)
+set(luadist2_VERSION 0.7-1)
 
 set(ENV{LUA_DIR} ${CMAKE_INSTALL_PREFIX})
 find_package(Lua REQUIRED)

--- a/dist/config.in.lua
+++ b/dist/config.in.lua
@@ -22,6 +22,11 @@ local_manifest_file = pl.path.join(share_dir, manifest_filename)
 
 -- Repositories ------------------------------------------------------
 manifest_repos = {
+    -- Local directories. They are scanned, when searching for
+    -- packages present in local filesystem.
+    -- Note: local flesystem dirs must be stated as absolute path and put before git
+    -- manifests.
+
     -- Manually updated core manifest, contains lua, lua-git, zlib packages and
     -- everything other that should not go through LuaRocks management
     "git://github.com/LuaDist-core/manifest.git",

--- a/dist/manifest.lua
+++ b/dist/manifest.lua
@@ -2,17 +2,18 @@ local log = require "dist.log".logger
 local cfg = require "dist.config"
 local git = require "dist.git"
 local utils = require "dist.utils"
+local ordered = require "dist.ordered"
 local pl = require "pl.import_into"()
 
 local manifest_module = {}
 
 -- Return the joined manifest table from 'cfg.manifest_repos' locations
 local manifest = nil
-function manifest_module.get_manifest()
+function manifest_module.get_manifest(include_local_repos)
     -- Download manifest if this is first time we are requesting it in this run,
     -- otherwise it is cached in memory until luadist is terminated
     if manifest == nil then
-        manifest, err = manifest_module.download_manifest(cfg.manifest_repos)
+        manifest, err = manifest_module.download_manifest(cfg.manifest_repos,include_local_repos)
         if not manifest then
             return nil, "Error downloading manifest: " .. err
         end
@@ -23,7 +24,7 @@ end
 
 -- Download manifest from the table of git 'manifest_urls' and return manifest
 -- table on success and nil and error message on error.
-function manifest_module.download_manifest(manifest_urls)
+function manifest_module.download_manifest(manifest_urls,include_local_repos)
     manifest_urls = manifest_urls or cfg.manifest_repos
     if type(manifest_urls) == "string" then manifest_urls = {manifest_urls} end
 
@@ -38,54 +39,62 @@ function manifest_module.download_manifest(manifest_urls)
 
     log:info("Downloading manifest information...")
     for k, repo in pairs(manifest_urls) do
-        local clone_dir = pl.path.join(cfg.temp_dir_abs, "manifest_" .. tostring(k))
 
-        -- Clone the repo and add its 'manifest-file' file to the manifest table
-        ok, err = git.create_repo(clone_dir)
+        if manifest_module.is_remote(repo) then
+            clone_dir = pl.path.join(cfg.temp_dir_abs, "manifest_" .. tostring(k))
 
-        local sha
-        if ok then sha, err = git.fetch_branch(clone_dir, repo, "master") end
-        if sha then ok, err = git.checkout_sha(sha, clone_dir) end
+            -- Clone the repo and add its 'manifest-file' file to the manifest table
+            ok, err = git.create_repo(clone_dir)
 
-        if not (ok and sha) then
-            if not cfg.debug then
-                pl.dir.rmtree(clone_dir)
+            local sha
+            if ok then sha, err = git.fetch_branch(clone_dir, repo, "master") end
+            if sha then ok, err = git.checkout_sha(sha, clone_dir) end
+
+            if not (ok and sha) then
+                if not cfg.debug then
+                    pl.dir.rmtree(clone_dir)
+                end
+
+                return nil, "Could not download manifest from repository with url: '" .. repo .. "': " .. err
             end
 
-            return nil, "Could not download manifest from repository with url: '" .. repo .. "': " .. err
-        else
             local manifest_file = pl.path.join(clone_dir, cfg.manifest_filename)
-            local current_manifest, err = manifest_module.load_manifest(manifest_file)
+            current_manifest, err = manifest_module.load_manifest(manifest_file)
+        elseif include_local_repos then
+            current_manifest,err=manifest_module.generate_local_manifest(repo)
+        else
+            err = "Local repo found. To install from local repos use 'make' command."
+        end
 
-            if current_manifest then
-                -- Merge manifest.package tables on first two levels (package name and version)
-                -- Note: Don't use pl.tablex.merge because it would merge even dependencies if the same
-                -- package version is present in two different manifests, we want to keep dependencies
-                -- from manifest earlier in 'manifest_urls'
-                for pkg, info in pairs(current_manifest.packages) do
-                    -- Current manifest provides new package, add it
-                    if manifest.packages[pkg] == nil then
-                        manifest.packages[pkg] = info
-                    -- Add all versions which were not present in earlier manifests
-                    else
-                        for version, deps in pairs(info) do
-                            if manifest.packages[pkg][version] == nil then
-                                manifest.packages[pkg][version] = deps
-                            end
+        if current_manifest then
+            -- Merge manifest.package tables on first two levels (package name and version)
+            -- Note: Don't use pl.tablex.merge because it would merge even dependencies if the same
+            -- package version is present in two different manifests, we want to keep dependencies
+            -- from manifest earlier in 'manifest_urls'
+            for pkg, info in pairs(current_manifest.packages) do
+                -- Current manifest provides new package, add it
+                if manifest.packages[pkg] == nil then
+                    manifest.packages[pkg] = info
+                -- Add all versions which were not present in earlier manifests
+                else
+                    for version, deps in pairs(info) do
+                        if manifest.packages[pkg][version] == nil then
+                            manifest.packages[pkg][version] = deps
                         end
                     end
                 end
-
-                table.insert(manifest.repo_path, current_manifest.repo_path)
-            else
-                return nil, "Could not load manifest from repository with url: '" .. repo .. "': " .. err
             end
+
+            table.insert(manifest.repo_path, current_manifest.repo_path)
+        else
+            return nil, "Could not load manifest from repository with url: '" .. repo .. "': " .. err
         end
-        if not cfg.debug then
+
+        if not cfg.debug and manifest_module.is_remote(repo) then
             pl.dir.rmtree(clone_dir)
+
         end
     end
-
     -- Save the new manifest table to file for debug purposes
     if cfg.debug then
         pl.pretty.dump(manifest, pl.path.join(cfg.temp_dir_abs, cfg.manifest_filename))
@@ -168,6 +177,74 @@ end
 -- if rockspec file is not present, return nil.
 function manifest_module.load_rockspec(rockspec_file)
     return load_file(rockspec_file, pl.pretty.load)
+end
+
+-- Creates local manifest table, which has the same format as manifests from the remote repository.
+-- Manifest contains all packages present in the deploy_dir. Function is searching for .rockspec files in all
+-- subdirectories of deploy_dir, but only 1 level deep.
+-- returns manifest table
+function manifest_module.generate_local_manifest(deploy_dir)
+
+    -- Get all subdirectories
+    local subdirectories = pl.dir.getdirectories(deploy_dir)
+
+    local local_manifest = ordered.Ordered()
+
+    local_manifest["packages"] = {}
+    local local_rockspec_files = {}
+
+    -- get all 'rockspec' files in 'cfg.root_dir' subdirectories,
+    -- searching only 1 level deep.
+    for _ ,subdir in pairs(subdirectories) do
+        local rockspec_files = pl.dir.getfiles(subdir, "*.rockspec")
+        for _ ,rockspec in pairs(rockspec_files) do
+            table.insert(local_rockspec_files, rockspec)
+        end
+    end
+
+    local packages_in_manifest = {}
+
+    -- Iterate through all found rockspecs
+    for _, local_rockspec_file in pairs(local_rockspec_files) do
+
+        local pkg = {}
+        local local_rockspec = manifest_module.load_rockspec(local_rockspec_file)
+
+        if not local_rockspec then
+            log:error("Local rockspec "..local_rockspec_file.."could not be loaded")
+        else
+            -- Fetch info about the package from the rockspec
+            local pkg_name = local_rockspec["package"]
+            local pkg_version = local_rockspec["version"]
+            deps = {}
+            deps["dependencies"] = local_rockspec["dependencies"]
+
+            if local_rockspec["supported_platforms"] then
+                deps["supported_platforms"] = local_rockspec["supported_platforms"]
+            end
+
+            local packages_from_rockspec = local_manifest["packages"]
+
+            -- if there already was other version of package 'pkg name'
+            if packages_from_rockspec[pkg_name] then
+                pkg = packages_from_rockspec[pkg_name]
+            end
+
+            pkg[pkg_version] = deps
+            pkg[pkg_version]["local_url"] = pl.path.dirname(local_rockspec_file)
+            packages_in_manifest[pkg_name] = pkg
+        end
+        local_manifest["packages"] = packages_in_manifest
+    end
+    local_manifest["repo_path"] = deploy_dir
+
+    return local_manifest
+end
+
+--Test repo url if it is local or remote
+-- Returns true if repo is remote and false for local repo (local folder).
+function manifest_module.is_remote(repo)
+    return pl.stringx.startswith(repo,"git://")
 end
 
 return manifest_module

--- a/luadist.lua
+++ b/luadist.lua
@@ -100,11 +100,12 @@ Usage: luadist [DEPLOYMENT_DIRECTORY] install MODULES... [-VARIABLES...]
         help = [[
 Usage: luadist [DEPLOYMENT_DIRECTORY] make MODULES... [-VARIABLES...]
 
-    The 'make' command will install specified MODULES to
-    DEPLOYMENT_DIRECTORY.
-    MODULES with all dependencies that are not installed have to be present in the DEPLOYMENT_DIRECTORY saved in
-    subdirectories named 'module version'.
-    LuaDist will also automatically resolve and install all dependencies, if they are available. 
+    The 'make' command will install specified MODULES to DEPLOYMENT_DIRECTORY.
+
+    MODULES with all dependencies that are not installed have to be present in the DEPLOYMENT_DIRECTORY
+    saved in subdirectories named 'module version'. 
+
+    LuaDist will also automatically resolve and install all dependencies, if they are available.
 
     If DEPLOYMENT_DIRECTORY is not specified, the deployment directory
     of LuaDist is used.

--- a/luadist.lua
+++ b/luadist.lua
@@ -98,12 +98,13 @@ Usage: luadist [DEPLOYMENT_DIRECTORY] install MODULES... [-VARIABLES...]
     -- Make modules.
     ["make"] = {
         help = [[
-Usage: luadist [DEPLOYMENT_DIRECTORY] make MODULES... [-VARIABLES...]
+Usage: luadist [DEPLOYMENT_DIRECTORY] make [-VARIABLES...]
 
-    The 'make' command will install specified MODULES to DEPLOYMENT_DIRECTORY.
+    The 'make' command will install module from DEPLOYMENT_DIRECTORY.
 
-    MODULES with all dependencies that are not installed have to be present in the DEPLOYMENT_DIRECTORY
-    saved in subdirectories named 'module version'. 
+    All Module files should be present in the DEPLOYMENT_DIRECTORY. LuaDist will scan DEPLOYMENT_DIRECTORY and
+    search for the .rockspec files. If there are multiple .rockspec files in DEPLOYMENT_DIRECTORY, LuaDist will
+    only install module described in the first found rockspec.
 
     LuaDist will also automatically resolve and install all dependencies, if they are available.
 
@@ -114,22 +115,16 @@ Usage: luadist [DEPLOYMENT_DIRECTORY] make MODULES... [-VARIABLES...]
     configuration VARIABLES (e.g. -variable=value) can be specified.
         ]],
 
-        run = function (deploy_dir, modules, cmake_variables)
-            deploy_dir = deploy_dir or cfg.root_dir
-            if type(modules) == "string" then modules = {modules} end
+        run = function (deploy_dir, cmake_variables)
+            deploy_dir = deploy_dir or pl.path.currentdir()
             cmake_variables = cmake_variables or {}
 
             assert(type(deploy_dir) == "string", "luadist.make: Argument 'deploy_dir' is not a string.")
-            assert(type(modules) == "table", "luadist.make: Argument 'modules' is not a string or table.")
             assert(type(cmake_variables) == "table", "luadist.make: Argument 'cmake_variables' is not a table.")
             deploy_dir = pl.path.abspath(deploy_dir)
 
-            if #modules == 0 then
-                print("No modules to make specified.")
-                return 0
-            end
-
-            local ok, err, status = dist.make(modules, deploy_dir, cmake_variables)
+            local ok, err, status = dist.make(deploy_dir, cmake_variables)
+            deploy_dir = cfg.root_dir
             if not ok then
                 print(err)
                 os.exit(status)

--- a/luadist2-0.7-1.rockspec
+++ b/luadist2-0.7-1.rockspec
@@ -1,10 +1,10 @@
 package = "luadist2"
-version = "0.7"
+version = "0.7-1"
 source = {
-    tag = "0.7",
+    tag = "0.7-1",
     url = "git://github.com/LuaDist-core/luadist2.git"
+    description = {
 }
-description = {
     summary = "Lua package manager",
     homepage = "https://github.com/f4rnham/luadist2.git",
     license = "MIT"


### PR DESCRIPTION
 Fix command 'make' , add local repos support, edit version

Support for local repo was added. User can add local directory as a
repo, which will be scanned. After that the manifest containing all the
packages in local_dir is created. Scanning local repos is optional.

Command 'make' was edited. Now user just types 'make' in the working
directory, which contains the package data including rockspec. Deps are
searched for in all the repos including local repos. If dependency isn't
present in the local_repo, it's fetched from the remote repo