### PR TITLE
 Fix ordering of different versions of the same package in manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 project(luadist2 C CXX)
-set(luadist2_VERSION 0.8-1)
+set(luadist2_VERSION 0.8-2)
 
 set(ENV{LUA_DIR} ${CMAKE_INSTALL_PREFIX})
 find_package(Lua REQUIRED)

--- a/dist/manifest.lua
+++ b/dist/manifest.lua
@@ -74,7 +74,11 @@ function manifest_module.download_manifest(manifest_urls)
             for pkg, info in pairs(current_manifest.packages) do
                 -- Current manifest provides new package, add it
                 if manifest.packages[pkg] == nil then
-                    manifest.packages[pkg] = info
+                    -- manifest.packages[pkg] = info
+                    manifest.packages[pkg] = ordered.Ordered()
+                    for version, deps in pairs(info) do
+                        manifest.packages[pkg][version] = deps
+                    end
                 -- Add all versions which were not present in earlier manifests
                 else
                     for version, deps in pairs(info) do

--- a/dist/manifest.lua
+++ b/dist/manifest.lua
@@ -74,7 +74,6 @@ function manifest_module.download_manifest(manifest_urls)
             for pkg, info in pairs(current_manifest.packages) do
                 -- Current manifest provides new package, add it
                 if manifest.packages[pkg] == nil then
-                    -- manifest.packages[pkg] = info
                     manifest.packages[pkg] = ordered.Ordered()
                     for version, deps in pairs(info) do
                         manifest.packages[pkg][version] = deps

--- a/luadist2-0.8-2.rockspec
+++ b/luadist2-0.8-2.rockspec
@@ -1,7 +1,7 @@
 package = "luadist2"
-version = "0.8-1"
+version = "0.8-2"
 source = {
-    tag = "0.8-1",
+    tag = "0.8-2",
     url = "git://github.com/LuaDist-core/luadist2.git"
 }
 description = {


### PR DESCRIPTION
Versions of package in final manifest are sorted in the order, as loaded from repo's manifests.
(Finally!)